### PR TITLE
Simplify global exception handling

### DIFF
--- a/src/main/kotlin/com/noom/interview/fullstack/sleep/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/noom/interview/fullstack/sleep/GlobalExceptionHandler.kt
@@ -1,12 +1,11 @@
 package com.noom.interview.fullstack.sleep
 
-import org.springframework.dao.*
+import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.dao.DuplicateKeyException
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus.*
 import org.springframework.http.ProblemDetail
 import org.springframework.http.ResponseEntity
-import org.springframework.jdbc.BadSqlGrammarException
-import org.springframework.jdbc.CannotGetJdbcConnectionException
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.context.request.WebRequest
@@ -18,19 +17,8 @@ class GlobalExceptionHandler : ResponseEntityExceptionHandler() {
   @ExceptionHandler(Exception::class)
   fun handleThrowable(ex: Exception, request: WebRequest): ResponseEntity<Any>? {
     val statusCode = when (ex) {
-      is BadSqlGrammarException -> INTERNAL_SERVER_ERROR
-      is CannotAcquireLockException -> CONFLICT
-      is CannotGetJdbcConnectionException -> SERVICE_UNAVAILABLE
-      is DataAccessResourceFailureException -> SERVICE_UNAVAILABLE
       is DuplicateKeyException -> CONFLICT
       is DataIntegrityViolationException -> BAD_REQUEST
-      is EmptyResultDataAccessException -> NOT_FOUND
-      is IncorrectResultSizeDataAccessException -> INTERNAL_SERVER_ERROR
-      is InvalidDataAccessApiUsageException -> BAD_REQUEST
-      is OptimisticLockingFailureException -> CONFLICT
-      is PermissionDeniedDataAccessException -> FORBIDDEN
-      is PessimisticLockingFailureException -> CONFLICT
-      is QueryTimeoutException -> REQUEST_TIMEOUT
       else -> INTERNAL_SERVER_ERROR
     }
     val body = ProblemDetail.forStatusAndDetail(statusCode, ex.message)

--- a/src/test/kotlin/com/noom/interview/fullstack/sleep/GlobalExceptionHandlerTest.kt
+++ b/src/test/kotlin/com/noom/interview/fullstack/sleep/GlobalExceptionHandlerTest.kt
@@ -1,0 +1,38 @@
+package com.noom.interview.fullstack.sleep
+
+import io.mockk.mockk
+import jakarta.servlet.http.HttpServletRequest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.dao.DuplicateKeyException
+import org.springframework.http.HttpStatus.*
+import org.springframework.web.context.request.ServletWebRequest
+
+class GlobalExceptionHandlerTest {
+
+  private val handler = GlobalExceptionHandler()
+  private val request = ServletWebRequest(mockk<HttpServletRequest>())
+
+  @Test
+  fun `should return 409 Conflict for DuplicateKeyException`() {
+    val exception = DuplicateKeyException("Duplicate key")
+    val response = handler.handleThrowable(exception, request)
+    assertThat(response?.statusCode).isEqualTo(CONFLICT)
+  }
+
+  @Test
+  fun `should return 400 Bad Request for DataIntegrityViolationException`() {
+    val exception = DataIntegrityViolationException("Data integrity violation")
+    val response = handler.handleThrowable(exception, request)
+    assertThat(response?.statusCode).isEqualTo(BAD_REQUEST)
+  }
+
+  @Test
+  fun `should return 500 Internal Server Error for generic exception`() {
+    val exception = Exception("Generic error")
+    val response = handler.handleThrowable(exception, request)
+    assertThat(response?.statusCode).isEqualTo(INTERNAL_SERVER_ERROR)
+  }
+
+}


### PR DESCRIPTION
- Simplified `GlobalExceptionHandler` by removing unused exception types
- Kept only essential database exceptions: `DuplicateKeyException` and `DataIntegrityViolationException`