### PR TITLE
Add pagination support

### DIFF
--- a/src/main/kotlin/com/noom/interview/fullstack/sleep/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/noom/interview/fullstack/sleep/GlobalExceptionHandler.kt
@@ -19,6 +19,7 @@ class GlobalExceptionHandler : ResponseEntityExceptionHandler() {
     val statusCode = when (ex) {
       is DuplicateKeyException -> CONFLICT
       is DataIntegrityViolationException -> BAD_REQUEST
+      is IllegalArgumentException -> BAD_REQUEST
       else -> INTERNAL_SERVER_ERROR
     }
     val body = ProblemDetail.forStatusAndDetail(statusCode, ex.message)

--- a/src/main/kotlin/com/noom/interview/fullstack/sleep/Helpers.kt
+++ b/src/main/kotlin/com/noom/interview/fullstack/sleep/Helpers.kt
@@ -1,0 +1,10 @@
+package com.noom.interview.fullstack.sleep
+
+import com.noom.interview.fullstack.sleep.model.Pagination
+import org.jooq.Record
+import org.jooq.SelectForUpdateStep
+import org.jooq.SelectLimitStep
+
+fun <R : Record> SelectLimitStep<R>.applyPagination(pagination: Pagination?): SelectForUpdateStep<R> {
+  return if (pagination != null) this.limit(pagination.limit).offset(pagination.offset) else this
+}

--- a/src/main/kotlin/com/noom/interview/fullstack/sleep/controller/SleepLogController.kt
+++ b/src/main/kotlin/com/noom/interview/fullstack/sleep/controller/SleepLogController.kt
@@ -3,6 +3,7 @@ package com.noom.interview.fullstack.sleep.controller
 import com.noom.interview.fullstack.sleep.NotFoundException
 import com.noom.interview.fullstack.sleep.UnprocessableEntityException
 import com.noom.interview.fullstack.sleep.model.CreateSleepLogRequest
+import com.noom.interview.fullstack.sleep.model.Pagination
 import com.noom.interview.fullstack.sleep.model.SleepLog
 import com.noom.interview.fullstack.sleep.model.SleepStats
 import com.noom.interview.fullstack.sleep.service.SleepLogService
@@ -27,8 +28,13 @@ class SleepLogController(private val sleepLogService: SleepLogService) {
   }
 
   @GetMapping
-  fun findAll(@PathVariable(value = "user-id") userId: UUID): ResponseEntity<List<SleepLog>> {
-    val sleepLogs = sleepLogService.findAll(userId)
+  fun findAll(
+    @PathVariable(value = "user-id") userId: UUID,
+    @RequestParam(value = "page", required = false, defaultValue = "1") page: Int,
+    @RequestParam(value = "pageSize", required = false, defaultValue = "20") pageSize: Int
+  ): ResponseEntity<List<SleepLog>> {
+    val pagination = Pagination.fromPageAndSize(page, pageSize)
+    val sleepLogs = sleepLogService.findAll(userId, pagination)
     return ResponseEntity(sleepLogs, HttpStatus.OK)
   }
 

--- a/src/main/kotlin/com/noom/interview/fullstack/sleep/controller/UserController.kt
+++ b/src/main/kotlin/com/noom/interview/fullstack/sleep/controller/UserController.kt
@@ -2,6 +2,7 @@ package com.noom.interview.fullstack.sleep.controller
 
 import com.noom.interview.fullstack.sleep.NotFoundException
 import com.noom.interview.fullstack.sleep.model.CreateUserRequest
+import com.noom.interview.fullstack.sleep.model.Pagination
 import com.noom.interview.fullstack.sleep.model.User
 import com.noom.interview.fullstack.sleep.service.UserService
 import jakarta.validation.Valid
@@ -21,8 +22,12 @@ class UserController(private val userService: UserService) {
   }
 
   @GetMapping
-  fun findAll(): ResponseEntity<List<User>> {
-    val users = userService.findAll()
+  fun findAll(
+    @RequestParam(value = "page", required = false, defaultValue = "1") page: Int,
+    @RequestParam(value = "pageSize", required = false, defaultValue = "20") pageSize: Int
+  ): ResponseEntity<List<User>> {
+    val pagination = Pagination.fromPageAndSize(page, pageSize)
+    val users = userService.findAll(pagination)
     return ResponseEntity(users, HttpStatus.OK)
   }
 

--- a/src/main/kotlin/com/noom/interview/fullstack/sleep/model/Pagination.kt
+++ b/src/main/kotlin/com/noom/interview/fullstack/sleep/model/Pagination.kt
@@ -1,0 +1,26 @@
+package com.noom.interview.fullstack.sleep.model
+
+data class Pagination(
+  val limit: Int = 20,
+  val offset: Int = 0
+) {
+
+  init {
+    require(offset >= 0) { "Offset must be non-negative" }
+    require(limit > 0) { "Limit must be positive" }
+    require(limit <= 100) { "Limit must be less than or equal to 100" }
+  }
+
+  companion object {
+    fun fromPageAndSize(page: Int = 1, pageSize: Int = 20): Pagination {
+      require(page > 0) { "Page must be positive" }
+      require(pageSize > 0) { "Page size must be positive" }
+      require(pageSize <= 100) { "Page size must be less than or equal to 100" }
+      return Pagination(
+        limit = pageSize,
+        offset = pageSize * (page - 1)
+      )
+    }
+  }
+
+}

--- a/src/main/kotlin/com/noom/interview/fullstack/sleep/repository/SleepLogRepository.kt
+++ b/src/main/kotlin/com/noom/interview/fullstack/sleep/repository/SleepLogRepository.kt
@@ -1,12 +1,10 @@
 package com.noom.interview.fullstack.sleep.repository
 
+import com.noom.interview.fullstack.sleep.applyPagination
 import com.noom.interview.fullstack.sleep.jooq.enums.Mood
 import com.noom.interview.fullstack.sleep.jooq.tables.SleepLogs.Companion.SLEEP_LOGS
 import com.noom.interview.fullstack.sleep.jooq.tables.records.SleepLogsRecord
-import com.noom.interview.fullstack.sleep.model.CreateSleepLogRequest
-import com.noom.interview.fullstack.sleep.model.MoodFrequencies
-import com.noom.interview.fullstack.sleep.model.SleepLog
-import com.noom.interview.fullstack.sleep.model.SleepStats
+import com.noom.interview.fullstack.sleep.model.*
 import org.jooq.DSLContext
 import org.jooq.impl.DSL.*
 import org.jooq.impl.SQLDataType.*
@@ -34,11 +32,12 @@ class SleepLogRepository(private val jooq: DSLContext) {
       .fetchSingle { it.toModel() }
   }
 
-  fun findAll(userId: UUID): List<SleepLog> {
+  fun findAll(userId: UUID, pagination: Pagination? = null): List<SleepLog> {
     return jooq
       .selectFrom(SLEEP_LOGS)
       .where(SLEEP_LOGS.USER_ID.eq(userId))
       .orderBy(SLEEP_LOGS.DATE.desc())
+      .applyPagination(pagination)
       .fetch { it.toModel() }
   }
 

--- a/src/main/kotlin/com/noom/interview/fullstack/sleep/repository/UserRepository.kt
+++ b/src/main/kotlin/com/noom/interview/fullstack/sleep/repository/UserRepository.kt
@@ -1,8 +1,10 @@
 package com.noom.interview.fullstack.sleep.repository
 
+import com.noom.interview.fullstack.sleep.applyPagination
 import com.noom.interview.fullstack.sleep.jooq.tables.Users.Companion.USERS
 import com.noom.interview.fullstack.sleep.jooq.tables.records.UsersRecord
 import com.noom.interview.fullstack.sleep.model.CreateUserRequest
+import com.noom.interview.fullstack.sleep.model.Pagination
 import com.noom.interview.fullstack.sleep.model.User
 import org.jooq.DSLContext
 import org.springframework.stereotype.Repository
@@ -21,10 +23,11 @@ class UserRepository(private val jooq: DSLContext) {
       .fetchSingle { it.toModel() }
   }
 
-  fun findAll(): List<User> {
+  fun findAll(pagination: Pagination? = null): List<User> {
     return jooq
       .selectFrom(USERS)
       .orderBy(USERS.CREATED_AT.desc())
+      .applyPagination(pagination)
       .fetch { it.toModel() }
   }
 

--- a/src/main/kotlin/com/noom/interview/fullstack/sleep/service/SleepLogService.kt
+++ b/src/main/kotlin/com/noom/interview/fullstack/sleep/service/SleepLogService.kt
@@ -1,6 +1,7 @@
 package com.noom.interview.fullstack.sleep.service
 
 import com.noom.interview.fullstack.sleep.model.CreateSleepLogRequest
+import com.noom.interview.fullstack.sleep.model.Pagination
 import com.noom.interview.fullstack.sleep.model.SleepLog
 import com.noom.interview.fullstack.sleep.model.SleepStats
 import com.noom.interview.fullstack.sleep.repository.SleepLogRepository
@@ -16,8 +17,8 @@ class SleepLogService(private val sleepLogRepository: SleepLogRepository) {
     return sleepLogRepository.create(userId, newSleepLog)
   }
 
-  fun findAll(userId: UUID): List<SleepLog> {
-    return sleepLogRepository.findAll(userId)
+  fun findAll(userId: UUID, pagination: Pagination? = null): List<SleepLog> {
+    return sleepLogRepository.findAll(userId, pagination)
   }
 
   fun findLatest(userId: UUID): SleepLog? {

--- a/src/main/kotlin/com/noom/interview/fullstack/sleep/service/UserService.kt
+++ b/src/main/kotlin/com/noom/interview/fullstack/sleep/service/UserService.kt
@@ -1,6 +1,7 @@
 package com.noom.interview.fullstack.sleep.service
 
 import com.noom.interview.fullstack.sleep.model.CreateUserRequest
+import com.noom.interview.fullstack.sleep.model.Pagination
 import com.noom.interview.fullstack.sleep.model.User
 import com.noom.interview.fullstack.sleep.repository.UserRepository
 import org.springframework.stereotype.Service
@@ -15,8 +16,8 @@ class UserService(private val userRepository: UserRepository) {
     return userRepository.create(newUser)
   }
 
-  fun findAll(): List<User> {
-    return userRepository.findAll()
+  fun findAll(pagination: Pagination? = null): List<User> {
+    return userRepository.findAll(pagination)
   }
 
   fun findById(id: UUID): User? {

--- a/src/test/kotlin/com/noom/interview/fullstack/sleep/GlobalExceptionHandlerTest.kt
+++ b/src/test/kotlin/com/noom/interview/fullstack/sleep/GlobalExceptionHandlerTest.kt
@@ -29,6 +29,13 @@ class GlobalExceptionHandlerTest {
   }
 
   @Test
+  fun `should return 400 Bad Request for IllegalArgumentException`() {
+    val exception = IllegalArgumentException("Page size must be positive")
+    val response = handler.handleThrowable(exception, request)
+    assertThat(response?.statusCode).isEqualTo(BAD_REQUEST)
+  }
+
+  @Test
   fun `should return 500 Internal Server Error for generic exception`() {
     val exception = Exception("Generic error")
     val response = handler.handleThrowable(exception, request)

--- a/src/test/kotlin/com/noom/interview/fullstack/sleep/controller/SleepLogControllerTest.kt
+++ b/src/test/kotlin/com/noom/interview/fullstack/sleep/controller/SleepLogControllerTest.kt
@@ -6,6 +6,7 @@ import com.ninjasquad.springmockk.MockkBean
 import com.noom.interview.fullstack.sleep.createSleepLog
 import com.noom.interview.fullstack.sleep.createSleepLogRequest
 import com.noom.interview.fullstack.sleep.createSleepStats
+import com.noom.interview.fullstack.sleep.model.Pagination
 import com.noom.interview.fullstack.sleep.model.SleepLog
 import com.noom.interview.fullstack.sleep.model.SleepStats
 import com.noom.interview.fullstack.sleep.service.SleepLogService
@@ -96,18 +97,20 @@ class SleepLogControllerTest @Autowired constructor(
       createSleepLog(userId = userId),
       createSleepLog(userId = userId)
     )
-    every { sleepLogService.findAll(userId) } returns expectedSleepLogs
+    every { sleepLogService.findAll(userId, Pagination.fromPageAndSize(1, 2)) } returns expectedSleepLogs
 
     // When/Then
-    mockMvc.get("/api/v1/users/{user-id}/sleep-logs", userId)
-      .andExpect {
-        status { isOk() }
-      }.andDo {
-        handle { result ->
-          val actualSleepLogs = objectMapper.readValue<List<SleepLog>>(result.response.contentAsByteArray)
-          assertThat(actualSleepLogs).isEqualTo(expectedSleepLogs)
-        }
+    mockMvc.get("/api/v1/users/{user-id}/sleep-logs", userId) {
+      queryParam("page", "1")
+      queryParam("pageSize", "2")
+    }.andExpect {
+      status { isOk() }
+    }.andDo {
+      handle { result ->
+        val actualSleepLogs = objectMapper.readValue<List<SleepLog>>(result.response.contentAsByteArray)
+        assertThat(actualSleepLogs).isEqualTo(expectedSleepLogs)
       }
+    }
   }
 
   @Test

--- a/src/test/kotlin/com/noom/interview/fullstack/sleep/controller/UserControllerTest.kt
+++ b/src/test/kotlin/com/noom/interview/fullstack/sleep/controller/UserControllerTest.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import com.ninjasquad.springmockk.MockkBean
 import com.noom.interview.fullstack.sleep.createUser
 import com.noom.interview.fullstack.sleep.createUserRequest
+import com.noom.interview.fullstack.sleep.model.Pagination
 import com.noom.interview.fullstack.sleep.model.User
 import com.noom.interview.fullstack.sleep.service.UserService
 import com.noom.interview.fullstack.sleep.toUser
@@ -70,18 +71,20 @@ class UserControllerTest @Autowired constructor(
       createUser(),
       createUser()
     )
-    every { userService.findAll() } returns expectedUsers
+    every { userService.findAll(Pagination.fromPageAndSize(1, 2)) } returns expectedUsers
 
     // When/Then
-    mockMvc.get("/api/v1/users")
-      .andExpect {
-        status { isOk() }
-      }.andDo {
-        handle { result ->
-          val actualUsers = objectMapper.readValue<List<User>>(result.response.contentAsByteArray)
-          assertThat(actualUsers).isEqualTo(expectedUsers)
-        }
+    mockMvc.get("/api/v1/users") {
+      queryParam("page", "1")
+      queryParam("pageSize", "2")
+    }.andExpect {
+      status { isOk() }
+    }.andDo {
+      handle { result ->
+        val actualUsers = objectMapper.readValue<List<User>>(result.response.contentAsByteArray)
+        assertThat(actualUsers).isEqualTo(expectedUsers)
       }
+    }
   }
 
   @Test

--- a/src/test/kotlin/com/noom/interview/fullstack/sleep/repository/SleepLogRepositoryTest.kt
+++ b/src/test/kotlin/com/noom/interview/fullstack/sleep/repository/SleepLogRepositoryTest.kt
@@ -4,6 +4,7 @@ import com.noom.interview.fullstack.sleep.createSleepLogRequest
 import com.noom.interview.fullstack.sleep.createUserRequest
 import com.noom.interview.fullstack.sleep.jooq.enums.Mood
 import com.noom.interview.fullstack.sleep.model.MoodFrequencies
+import com.noom.interview.fullstack.sleep.model.Pagination
 import org.assertj.core.api.Assertions.*
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable
 import org.junit.jupiter.api.Test
@@ -91,6 +92,13 @@ class SleepLogRepositoryTest @Autowired constructor(
   fun `findAll should return all sleep logs for a user in order`() {
     // Given
     val user = userRepository.create(createUserRequest())
+    sleepLogRepository.create(
+      user.id,
+      createSleepLogRequest(
+        bedTime = Instant.now().minus(48 + 8, ChronoUnit.HOURS),
+        wakeTime = Instant.now().minus(48, ChronoUnit.HOURS)
+      )
+    )
     val sleepLog1 = sleepLogRepository.create(
       user.id,
       createSleepLogRequest(
@@ -99,9 +107,10 @@ class SleepLogRepositoryTest @Autowired constructor(
       )
     )
     val sleepLog2 = sleepLogRepository.create(user.id, createSleepLogRequest())
+    val pagination = Pagination(limit = 2, offset = 0)
 
     // When
-    val sleepLogs = sleepLogRepository.findAll(user.id)
+    val sleepLogs = sleepLogRepository.findAll(user.id, pagination)
 
     // Then
     assertThat(sleepLogs).hasSize(2)


### PR DESCRIPTION
Add pagination support to Sleep Log and User APIs:
- Introduced `Pagination` class to handle pagination parameters
- Updated `SleepLogController` and `UserController` to accept pagination parameters in `findAll` methods
- Enhanced `GlobalExceptionHandler` to return 400 Bad Request for invalid page or page size