### PR TITLE
Enhance CI workflow for Docker builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: write
     services:
       postgres:
         image: postgres:17-alpine
@@ -41,16 +42,35 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        if: github.ref == 'refs/heads/main'
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Generate Docker metadata
         uses: docker/metadata-action@v5
         id: meta
         with:
           images: ghcr.io/yegor-usoltsev/noom-sleep-logger
+          tags: |
+            type=sha
+            type=edge
 
       - name: Build Docker image
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: false
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.ref == 'refs/heads/main' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}


### PR DESCRIPTION
Improve CI for Docker builds with multi-platform support and image publishing

Changes:
- Added package write permissions
- Set up QEMU & Buildx for multi-platform builds
- Enabled ghcr.io login on `main` branch
- Push images only from `main` branch