### PR TITLE
Add `X-Total-Count` to paginated endpoints

### DIFF
--- a/src/main/kotlin/com/noom/interview/fullstack/sleep/Helpers.kt
+++ b/src/main/kotlin/com/noom/interview/fullstack/sleep/Helpers.kt
@@ -7,8 +7,11 @@ import org.jooq.SelectForUpdateStep
 import org.jooq.SelectLimitStep
 import org.jooq.impl.DSL
 import org.jooq.impl.SQLDataType.TIMESTAMP
+import org.springframework.util.MultiValueMap
 import java.sql.Timestamp
 import java.time.ZoneId
+
+const val X_TOTAL_COUNT = "X-Total-Count"
 
 val UTC: ZoneId = ZoneId.of("UTC")
 
@@ -19,3 +22,7 @@ fun <R : Record> SelectLimitStep<R>.applyPagination(pagination: Pagination?): Se
 fun Field<Timestamp?>.atTimeZone(timeZone: Field<String?>): Field<Timestamp?> {
   return DSL.field("{0} at time zone {1}", TIMESTAMP, this, timeZone)
 }
+
+fun headersOf(vararg pairs: Pair<String, String>): MultiValueMap<String, String> = MultiValueMap.fromSingleValue(
+  mapOf(*pairs)
+)

--- a/src/main/kotlin/com/noom/interview/fullstack/sleep/controller/SleepLogController.kt
+++ b/src/main/kotlin/com/noom/interview/fullstack/sleep/controller/SleepLogController.kt
@@ -2,6 +2,8 @@ package com.noom.interview.fullstack.sleep.controller
 
 import com.noom.interview.fullstack.sleep.NotFoundException
 import com.noom.interview.fullstack.sleep.UnprocessableEntityException
+import com.noom.interview.fullstack.sleep.X_TOTAL_COUNT
+import com.noom.interview.fullstack.sleep.headersOf
 import com.noom.interview.fullstack.sleep.model.CreateSleepLogRequest
 import com.noom.interview.fullstack.sleep.model.Pagination
 import com.noom.interview.fullstack.sleep.model.SleepLog
@@ -35,7 +37,7 @@ class SleepLogController(private val sleepLogService: SleepLogService) {
   ): ResponseEntity<List<SleepLog>> {
     val pagination = Pagination.fromPageAndSize(page, pageSize)
     val sleepLogs = sleepLogService.findAll(userId, pagination)
-    return ResponseEntity(sleepLogs, HttpStatus.OK)
+    return ResponseEntity(sleepLogs.list, headersOf(X_TOTAL_COUNT to "${sleepLogs.totalSize}"), HttpStatus.OK)
   }
 
   @GetMapping("/latest")

--- a/src/main/kotlin/com/noom/interview/fullstack/sleep/controller/UserController.kt
+++ b/src/main/kotlin/com/noom/interview/fullstack/sleep/controller/UserController.kt
@@ -1,6 +1,8 @@
 package com.noom.interview.fullstack.sleep.controller
 
 import com.noom.interview.fullstack.sleep.NotFoundException
+import com.noom.interview.fullstack.sleep.X_TOTAL_COUNT
+import com.noom.interview.fullstack.sleep.headersOf
 import com.noom.interview.fullstack.sleep.model.CreateUserRequest
 import com.noom.interview.fullstack.sleep.model.Pagination
 import com.noom.interview.fullstack.sleep.model.User
@@ -28,7 +30,7 @@ class UserController(private val userService: UserService) {
   ): ResponseEntity<List<User>> {
     val pagination = Pagination.fromPageAndSize(page, pageSize)
     val users = userService.findAll(pagination)
-    return ResponseEntity(users, HttpStatus.OK)
+    return ResponseEntity(users.list, headersOf(X_TOTAL_COUNT to "${users.totalSize}"), HttpStatus.OK)
   }
 
   @GetMapping("/{user-id}")

--- a/src/main/kotlin/com/noom/interview/fullstack/sleep/model/Pagination.kt
+++ b/src/main/kotlin/com/noom/interview/fullstack/sleep/model/Pagination.kt
@@ -24,3 +24,8 @@ data class Pagination(
   }
 
 }
+
+class Page<T>(
+  val list: List<T>,
+  val totalSize: Int
+) : List<T> by list

--- a/src/main/kotlin/com/noom/interview/fullstack/sleep/repository/UserRepository.kt
+++ b/src/main/kotlin/com/noom/interview/fullstack/sleep/repository/UserRepository.kt
@@ -4,9 +4,11 @@ import com.noom.interview.fullstack.sleep.applyPagination
 import com.noom.interview.fullstack.sleep.jooq.tables.Users.Companion.USERS
 import com.noom.interview.fullstack.sleep.jooq.tables.records.UsersRecord
 import com.noom.interview.fullstack.sleep.model.CreateUserRequest
+import com.noom.interview.fullstack.sleep.model.Page
 import com.noom.interview.fullstack.sleep.model.Pagination
 import com.noom.interview.fullstack.sleep.model.User
 import org.jooq.DSLContext
+import org.jooq.kotlin.fetchSingleValue
 import org.springframework.stereotype.Repository
 import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
@@ -30,12 +32,18 @@ class UserRepository(private val jooq: DSLContext) {
       .fetchSingle { it.toModel() }
   }
 
-  fun findAll(pagination: Pagination? = null): List<User> {
-    return jooq
-      .selectFrom(USERS)
-      .orderBy(USERS.CREATED_AT.desc())
-      .applyPagination(pagination)
-      .fetch { it.toModel() }
+  fun findAll(pagination: Pagination? = null): Page<User> {
+    return Page(
+      list = jooq
+        .selectFrom(USERS)
+        .orderBy(USERS.CREATED_AT.desc())
+        .applyPagination(pagination)
+        .fetch { it.toModel() },
+      totalSize = jooq
+        .selectCount()
+        .from(USERS)
+        .fetchSingleValue()
+    )
   }
 
   fun findById(id: UUID): User? {

--- a/src/main/kotlin/com/noom/interview/fullstack/sleep/service/SleepLogService.kt
+++ b/src/main/kotlin/com/noom/interview/fullstack/sleep/service/SleepLogService.kt
@@ -1,9 +1,6 @@
 package com.noom.interview.fullstack.sleep.service
 
-import com.noom.interview.fullstack.sleep.model.CreateSleepLogRequest
-import com.noom.interview.fullstack.sleep.model.Pagination
-import com.noom.interview.fullstack.sleep.model.SleepLog
-import com.noom.interview.fullstack.sleep.model.SleepStats
+import com.noom.interview.fullstack.sleep.model.*
 import com.noom.interview.fullstack.sleep.repository.SleepLogRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -17,7 +14,7 @@ class SleepLogService(private val sleepLogRepository: SleepLogRepository) {
     return sleepLogRepository.create(userId, newSleepLog)
   }
 
-  fun findAll(userId: UUID, pagination: Pagination? = null): List<SleepLog> {
+  fun findAll(userId: UUID, pagination: Pagination? = null): Page<SleepLog> {
     return sleepLogRepository.findAll(userId, pagination)
   }
 

--- a/src/main/kotlin/com/noom/interview/fullstack/sleep/service/UserService.kt
+++ b/src/main/kotlin/com/noom/interview/fullstack/sleep/service/UserService.kt
@@ -1,6 +1,7 @@
 package com.noom.interview.fullstack.sleep.service
 
 import com.noom.interview.fullstack.sleep.model.CreateUserRequest
+import com.noom.interview.fullstack.sleep.model.Page
 import com.noom.interview.fullstack.sleep.model.Pagination
 import com.noom.interview.fullstack.sleep.model.User
 import com.noom.interview.fullstack.sleep.repository.UserRepository
@@ -16,7 +17,7 @@ class UserService(private val userRepository: UserRepository) {
     return userRepository.create(newUser)
   }
 
-  fun findAll(pagination: Pagination? = null): List<User> {
+  fun findAll(pagination: Pagination? = null): Page<User> {
     return userRepository.findAll(pagination)
   }
 

--- a/src/test/kotlin/com/noom/interview/fullstack/sleep/TestData.kt
+++ b/src/test/kotlin/com/noom/interview/fullstack/sleep/TestData.kt
@@ -9,6 +9,8 @@ import java.util.*
 val LAX: ZoneId = ZoneId.of("America/Los_Angeles") // UTC-08:00 / UTC-07:00 (DST)
 val WAW: ZoneId = ZoneId.of("Europe/Warsaw")       // UTC+01:00 / UTC+02:00 (DST)
 
+fun <T> List<T>.toPage(): Page<T> = Page(this, size)
+
 fun createUser(
   id: UUID = UUID.randomUUID(),
   name: String = "${UUID.randomUUID()}",

--- a/src/test/kotlin/com/noom/interview/fullstack/sleep/controller/SleepLogControllerTest.kt
+++ b/src/test/kotlin/com/noom/interview/fullstack/sleep/controller/SleepLogControllerTest.kt
@@ -93,7 +93,7 @@ class SleepLogControllerTest @Autowired constructor(
     val expectedSleepLogs = listOf(
       createSleepLog(userId = userId),
       createSleepLog(userId = userId)
-    )
+    ).toPage()
     every { sleepLogService.findAll(userId, Pagination.fromPageAndSize(1, 2)) } returns expectedSleepLogs
 
     // When/Then
@@ -102,6 +102,7 @@ class SleepLogControllerTest @Autowired constructor(
       queryParam("page-size", "2")
     }.andExpect {
       status { isOk() }
+      header { string(X_TOTAL_COUNT, "2") }
     }.andDo {
       handle { result ->
         val actualSleepLogs = objectMapper.readValue<List<SleepLog>>(result.response.contentAsByteArray)

--- a/src/test/kotlin/com/noom/interview/fullstack/sleep/controller/UserControllerTest.kt
+++ b/src/test/kotlin/com/noom/interview/fullstack/sleep/controller/UserControllerTest.kt
@@ -69,7 +69,7 @@ class UserControllerTest @Autowired constructor(
     val expectedUsers = listOf(
       createUser(timeZone = LAX),
       createUser(timeZone = WAW)
-    )
+    ).toPage()
     every { userService.findAll(Pagination.fromPageAndSize(1, 2)) } returns expectedUsers
 
     // When/Then
@@ -78,6 +78,7 @@ class UserControllerTest @Autowired constructor(
       queryParam("page-size", "2")
     }.andExpect {
       status { isOk() }
+      header { string(X_TOTAL_COUNT, "2") }
     }.andDo {
       handle { result ->
         val actualUsers = objectMapper.readValue<List<User>>(result.response.contentAsByteArray)

--- a/src/test/kotlin/com/noom/interview/fullstack/sleep/service/SleepLogServiceTest.kt
+++ b/src/test/kotlin/com/noom/interview/fullstack/sleep/service/SleepLogServiceTest.kt
@@ -38,7 +38,7 @@ class SleepLogServiceTest {
     val expectedSleepLogs = listOf(
       createSleepLog(userId = userId),
       createSleepLog(userId = userId)
-    )
+    ).toPage()
     every { sleepLogRepository.findAll(userId) } returns expectedSleepLogs
 
     // When

--- a/src/test/kotlin/com/noom/interview/fullstack/sleep/service/UserServiceTest.kt
+++ b/src/test/kotlin/com/noom/interview/fullstack/sleep/service/UserServiceTest.kt
@@ -3,6 +3,7 @@ package com.noom.interview.fullstack.sleep.service
 import com.noom.interview.fullstack.sleep.createUser
 import com.noom.interview.fullstack.sleep.createUserRequest
 import com.noom.interview.fullstack.sleep.repository.UserRepository
+import com.noom.interview.fullstack.sleep.toPage
 import com.noom.interview.fullstack.sleep.toUser
 import io.mockk.every
 import io.mockk.mockk
@@ -37,7 +38,7 @@ class UserServiceTest {
     val expectedUsers = listOf(
       createUser(),
       createUser()
-    )
+    ).toPage()
     every { userRepository.findAll() } returns expectedUsers
 
     // When


### PR DESCRIPTION
Key Changes:
- Introduced `Page<T>` class to handle pagination results
- Updated repository layer to return `Page<T>` (including total count)
- Added `X-Total-Count` header to paginated endpoints
